### PR TITLE
Fix ex02 copy constructor and operator =

### DIFF
--- a/ex02/Squad.cpp
+++ b/ex02/Squad.cpp
@@ -1,10 +1,6 @@
 #include "Squad.hpp"
 
-const int	Squad::_start_units = 1;
-
-Squad::Squad() :
-	_max_size(_start_units), _count(0),
-	_units(new ISpaceMarine*[_start_units]) {
+Squad::Squad() : _max_size(0), _count(0), _units(0) {
 }
 
 Squad::Squad(Squad const & src) {
@@ -16,7 +12,7 @@ Squad &			Squad::operator=(Squad const & rhs) {
 		_erase();
 		_max_size = rhs.getMaxSize();
 		_count = rhs.getCount();
-		_units = new ISpaceMarine*[rhs.getCount()];
+		_units = new ISpaceMarine*[rhs.getMaxSize()];
 		for (int i = 0; i < _count; i++) {
 			_units[i] = rhs.getUnit(i)->clone();
 		}
@@ -45,7 +41,7 @@ int				Squad::push(ISpaceMarine *unit) {
 		return _count;
 	}
 	if (_count == _max_size) {
-		int	new_max_size = _max_size * 2;
+		int	new_max_size = _max_size ? _max_size * 2 : 1;
 		ISpaceMarine** new_units = new ISpaceMarine*[new_max_size];
 
 		std::memcpy(new_units, _units, sizeof(ISpaceMarine *) * _count);

--- a/ex02/Squad.hpp
+++ b/ex02/Squad.hpp
@@ -23,7 +23,6 @@ class Squad : public ISquad {
 	ISpaceMarine**		_units;
 	void				_erase();
 	bool				_is_duplicate(ISpaceMarine *unit);
-	static const int	_start_units;
 };
 
 #endif  // SQUAD_HPP_


### PR DESCRIPTION
Fixed a case in copy constructor of Squad
Now is allocating memory for the maximum number of units instead of
current units that are in squad

Removed the _starting_units variable and starting with 0 units
When expanding the array if max units is 0 will allocate memory for 1 unit
then each expansion will realocate the double of the maximum units