### PR TITLE
ex03 Remove const from the parameter of use()

### DIFF
--- a/ex03/AMateria.cpp
+++ b/ex03/AMateria.cpp
@@ -26,7 +26,7 @@ unsigned int		AMateria::getXP() const {
 	return _xp;
 }
 
-void				AMateria::use(ICharacter const &) {
+void				AMateria::use(ICharacter&) {
 	_xp += 10;
 }
 

--- a/ex03/AMateria.hpp
+++ b/ex03/AMateria.hpp
@@ -13,7 +13,7 @@ class AMateria {
 	std::string const &	getType() const;  // Returns the materia type
 	unsigned int		getXP() const;  // Returns the Materia's XP
 	virtual AMateria*	clone() const = 0;
-	virtual void		use(ICharacter const & target);
+	virtual void		use(ICharacter& target);
 	void				setXP(unsigned int xp);
 
  private:

--- a/ex03/Character.cpp
+++ b/ex03/Character.cpp
@@ -55,7 +55,7 @@ void		Character::unequip(int idx) {
 	}
 }
 
-void		Character::use(int idx, ICharacter const & target) {
+void		Character::use(int idx, ICharacter& target) {
 	if (idx >= 0 && idx < _n_current_items) {
 		_inventory[idx]->use(target);
 	}

--- a/ex03/Character.hpp
+++ b/ex03/Character.hpp
@@ -15,7 +15,7 @@ class Character : public ICharacter {
 	std::string const &	getName() const;
 	void				equip(AMateria* m);
 	void 				unequip(int idx);
-	void 				use(int idx, ICharacter const & target);
+	void 				use(int idx, ICharacter& target);
 
  private:
 	std::string			_name;

--- a/ex03/Cure.cpp
+++ b/ex03/Cure.cpp
@@ -23,7 +23,7 @@ AMateria*	Cure::clone() const {
 	return copy;
 }
 
-void		Cure::use(ICharacter const & target) {
+void		Cure::use(ICharacter& target) {
 	std::cout << "* heals " << target.getName() << "’s wounds *\n";
 	AMateria::use(target);
 }

--- a/ex03/Cure.hpp
+++ b/ex03/Cure.hpp
@@ -11,7 +11,7 @@ class Cure : public AMateria {
 	Cure &		operator=(Cure const & rhs);
 				~Cure();
 	AMateria*	clone() const;
-	void		use(ICharacter const & target);
+	void		use(ICharacter& target);
 };
 
 #endif  // CURE_HPP_

--- a/ex03/ICharacter.hpp
+++ b/ex03/ICharacter.hpp
@@ -12,7 +12,7 @@ class ICharacter {
 	virtual	std::string const & getName() const = 0;
 	virtual	void equip(AMateria* m) = 0;
 	virtual	void unequip(int idx) = 0;
-	virtual	void use(int idx, ICharacter const & target) = 0;
+	virtual	void use(int idx, ICharacter& target) = 0;
 };
 
 #endif  // ICHARACTER_HPP_

--- a/ex03/Ice.cpp
+++ b/ex03/Ice.cpp
@@ -23,7 +23,7 @@ AMateria*	Ice::clone() const {
 	return copy;
 }
 
-void		Ice::use(ICharacter const & target) {
+void		Ice::use(ICharacter& target) {
 	std::cout << "* shoots an ice bolt at " << target.getName() << " *\n";
 	AMateria::use(target);
 }

--- a/ex03/Ice.hpp
+++ b/ex03/Ice.hpp
@@ -11,7 +11,7 @@ class Ice : public AMateria {
 	Ice &		operator=(Ice const & rhs);
 				~Ice();
 	AMateria*	clone() const;
-	void		use(ICharacter const & target);
+	void		use(ICharacter& target);
 };
 
 #endif  // ICE_HPP_


### PR DESCRIPTION
Removed the const from the target parameter
in order to have the same prototype as in the subject
Same change in all the derived classes